### PR TITLE
Remove a mention of Crate from the contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Crate Contribution Guidelines
+# Contribution Guidelines
 
 Please visit the [master copy](https://github.com/cratekube/cratekube/blob/master/CONTRIBUTING.md) of CrateKube's contribution guidelines.


### PR DESCRIPTION
This is part of the work for cratekube/cratekube#12

Signed-off-by: Philip Grenon <phgrenon@cisco.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cratekube/dropwizard-groovy-template/35)
<!-- Reviewable:end -->
